### PR TITLE
Add a unique integer id for github repositories

### DIFF
--- a/migrations/20230503141730-github-id.js
+++ b/migrations/20230503141730-github-id.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230503141730-github-id-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230503141730-github-id-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20230503141730-github-id-up.sql
+++ b/migrations/sqls/20230503141730-github-id-up.sql
@@ -1,0 +1,3 @@
+-- Add an integer identifier for github repos for efficiency in tables that reference repositories
+-- This will be automatically backfilled for existing rows.
+alter table github.repository add column id_int serial unique not null;


### PR DESCRIPTION
This is for efficiency in tables that have large numbers of references to github repos - ints are much more efficient than full url strings when doing analysis.
