### PR TITLE
Avoid locking dashboard during jenkins processing

### DIFF
--- a/migrations/20230728113233-jenkins-perf.js
+++ b/migrations/20230728113233-jenkins-perf.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230728113233-jenkins-perf-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230728113233-jenkins-perf-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20230728113233-jenkins-perf-up.sql
+++ b/migrations/sqls/20230728113233-jenkins-perf-up.sql
@@ -1,0 +1,1 @@
+create unique index on jenkins_impl.terminal_build_steps_materialized(correlation_id);

--- a/src/main/query/jenkins.metrics.test.ts
+++ b/src/main/query/jenkins.metrics.test.ts
@@ -3,6 +3,7 @@ import { Pool } from 'pg';
 import { startPostgres, stopPostgres } from '../../test/support/docker';
 import * as fs from 'fs';
 import { silenceMigrations } from '../../test/support/migrate';
+import { getMetrics } from '../jenkins/cosmos';
 
 jest.setTimeout(180_000);
 jest.mock('../jenkins/cosmos', () => ({ getMetrics: () => fs.readFileSync('src/test/data/jenkins-metrics.json', 'utf-8') }));
@@ -17,6 +18,9 @@ describe('metrics', () => {
 
     const { config } = require('../config');
     pool = new Pool({ connectionString: config.dbUrl });
+    // Run the processing a second time, should be idempotent
+    const { processCosmosResults } = require('./jenkins.metrics');
+    await processCosmosResults(pool, await getMetrics(BigInt(0)));
   });
 
   afterAll(async () => {

--- a/src/main/query/jenkins.metrics.ts
+++ b/src/main/query/jenkins.metrics.ts
@@ -4,10 +4,10 @@ import { pool } from '../db/store';
 
 export const run = async () => {
   const items = await getMetrics(await getUnixTimeToQueryFrom(pool));
-  return processCosmosResults(items);
+  return processCosmosResults(pool, items);
 };
 
-const processCosmosResults = async (json: string) => {
+export const processCosmosResults = async (pool: Pool, json: string) => {
   await pool.query(
     `
   with builds as (


### PR DESCRIPTION
The transactional truncate/repopulate of the terminal build steps table results in an access exclusive lock on that table and therefore hangs the dashboard.