### PR TITLE
Fix empty CVE reports not being recorded

### DIFF
--- a/src/main/query/security.cves.test.ts
+++ b/src/main/query/security.cves.test.ts
@@ -25,7 +25,8 @@ describe('cves', () => {
           ('https://github.com/hmcts/fpl-ccd-configuration', '', '', '', ''),
           ('https://github.com/hmcts/ccd-data-store-api', '', '', '', ''),
           ('https://github.com/hmcts/prl-ccd-definitions', '', '', '', ''),
-          ('https://github.com/hmcts/Sscs-submit-your-appeal', '', '', '', '')
+          ('https://github.com/hmcts/Sscs-submit-your-appeal', '', '', '', ''),
+          ('https://github.com/hmcts/lau-frontend', '', '', '', '')
     `);
 
     const { runFiles } = require('../executor');
@@ -54,6 +55,7 @@ describe('cves', () => {
       ['https://github.com/hmcts/prl-ccd-definitions', 'https://github.com/advisories/GHSA-56x4-j7p9-fcf9', 'low'],
       ['https://github.com/hmcts/Sscs-submit-your-appeal', 'CVE-2020-24025', 'medium'],
       ['https://github.com/hmcts/Sscs-submit-your-appeal', 'CVE-2023-28155', 'medium'],
+      // lau-frontend had CVEs on a prior report but not latest, so should not show up.
     ]);
   });
 });

--- a/src/test/data/cve-reports.json
+++ b/src/test/data/cve-reports.json
@@ -465,5 +465,111 @@
     "_etag": "\"15000b18-0000-1100-0000-6453c8170000\"",
     "_attachments": "attachments/",
     "_ts": 1683212311
+  },
+  {
+    "id": "b564d047-9688-4c8a-a4a5-ede954b2250c",
+    "build": {
+      "branch_name": "master",
+      "build_display_name": "#108",
+      "build_tag": "jenkins-HMCTS_j_to_z-lau-frontend-master-366",
+      "git_url": "https://github.com/HMCTS/lau-frontend.git",
+      "codebase_type": "node"
+    },
+    "report": {
+      "vulnerabilities": [
+        {
+          "title": null,
+          "cves": null,
+          "vulnerable_versions": null,
+          "patched_versions": null,
+          "severity": null,
+          "cwe": null,
+          "url": null,
+          "module_name": null
+        },
+        {
+          "title": "Command Injection in moment-timezone",
+          "cves": [],
+          "vulnerable_versions": ">=0.1.0 <0.5.35",
+          "patched_versions": ">=0.5.35",
+          "severity": "low",
+          "cwe": [],
+          "url": "https://github.com/advisories/GHSA-56x4-j7p9-fcf9",
+          "module_name": "moment-timezone"
+        }
+      ],
+      "summary": {
+        "dependencies": 12,
+        "devDependencies": 0,
+        "optionalDependencies": 0,
+        "totalDependencies": 12,
+        "vulnerabilities": {
+          "critical": 0,
+          "high": 0,
+          "info": 0,
+          "low": 0,
+          "moderate": 0
+        }
+      },
+      "suppressed": [
+        {
+          "title": "Server-Side Request Forgery in Request",
+          "cves": ["CVE-2023-28155"],
+          "vulnerable_versions": "<=2.88.2",
+          "patched_versions": "<0.0.0",
+          "severity": "moderate",
+          "cwe": ["CWE-918"],
+          "url": "https://github.com/advisories/GHSA-p8p7-x288-28g6",
+          "module_name": "request"
+        }
+      ]
+    },
+    "_rid": "39IWAII4oFPR-g0AAAAAAA==",
+    "_self": "dbs/39IWAA==/colls/39IWAII4oFM=/docs/39IWAII4oFPR-g0AAAAAAA==/",
+    "_etag": "\"15000b18-0000-1100-0000-6453c8170000\"",
+    "_attachments": "attachments/",
+    "_ts": 1683212312
+  },
+  {
+    "id": "284e4e22-7564-4754-a7da-b63419a294cf",
+    "build": {
+      "branch_name": "master",
+      "build_display_name": "#366",
+      "build_tag": "jenkins-HMCTS_j_to_z-lau-frontend-master-366",
+      "git_url": "https://github.com/HMCTS/lau-frontend.git",
+      "codebase_type": "node"
+    },
+    "report": {
+      "vulnerabilities": [
+        {
+          "title": null,
+          "cves": null,
+          "vulnerable_versions": null,
+          "patched_versions": null,
+          "severity": null,
+          "cwe": null,
+          "url": null,
+          "module_name": null
+        }
+      ],
+      "summary": {
+        "dependencies": 370,
+        "devDependencies": 2,
+        "optionalDependencies": 0,
+        "totalDependencies": 372,
+        "vulnerabilities": {
+          "critical": 0,
+          "high": 0,
+          "info": 0,
+          "low": 0,
+          "moderate": 0
+        }
+      }
+    },
+    "_rid": "39IWAII4oFMG3hAAAAAAAA==",
+    "_self": "dbs/39IWAA==/colls/39IWAII4oFM=/docs/39IWAII4oFMG3hAAAAAAAA==/",
+    "_etag": "\"f800f43d-0000-1100-0000-6543eb3e0000\"",
+    "_attachments": "attachments/",
+    "_ts": 1698949950
   }
 ]


### PR DESCRIPTION
CVE reports with no CVEs would not get recorded, meaning teams who get to zero CVEs would end up with their last non-zero CVE report as their current status.
